### PR TITLE
Track page view based on plugin option `trackPageView`

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,9 @@ _NOTE: By default, this plugin only generates output when run in production mode
 | `localScript`     | (optional) If set, load local `piwik.js` script from the given path, instead of loading it from your `matomoUrl`.                                                                                                                                                                                                  |
 | `trackLoad`       | (optional) If true, it will track the loading of the matomo library. Defaults to `true`.                                                                                                                                                                                                                           |
 | `respectDnt`      |  (optional) If false, will load all scripts without respecting user preference to `Do Not Track` on browsers.  Defaults to `true`.                                                                                                                                                                                 |
-| `dev`             | (optional) Activate dev mode by setting to `true`. Will load all scripts despite not running in `production` environment. Ignores your local browser's DNT header too. Outputs some information in console about what it is doing. Useful for local testing but careful: all hits will be send like in production. |
+| `dev`             | (optional) Activate dev mode by setting to `true`. Will load all scripts despite not running in `production` environment. Ignores your local browser's DNT header too. Outputs some information in console about what it is doing. Useful for local testing but careful: all hits will be send like in production.
+| `trackPageView`     | (optional) If true, it will log page view on matomo. Defaults to `true`.
+
 
 ```js
 plugins: [
@@ -97,7 +99,8 @@ plugins: [
       disableCookies: false,
       cookieDomain: '*.example.org',
       localScript: '/piwik.js',
-      dev: false
+      dev: false,
+      trackPageView: false,
     }
   }
 ]

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -22,7 +22,7 @@ export const onRouteUpdate = ({ location, prevLocation }, pluginOptions) => {
       prevLocation &&
       prevLocation.pathname + prevLocation.search + prevLocation.hash
 
-    const { trackLoad = true } = pluginOptions
+    const { trackLoad = true, trackPageView = true } = pluginOptions
 
     // document.title workaround stolen from:
     // https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-plugin-google-analytics/src/gatsby-browser.js
@@ -41,9 +41,12 @@ export const onRouteUpdate = ({ location, prevLocation }, pluginOptions) => {
       }
     }
 
-    // Minimum delay for reactHelmet's requestAnimationFrame
-    const delay = Math.max(32, 0)
-    setTimeout(sendPageView, delay)
+    // simulate 2 RAF calls
+    if(trackPageView){
+      const delay = Math.max(32, 0)
+      setTimeout(sendPageView, delay)
+    }
+    
 
     if (first) {
       first = false


### PR DESCRIPTION
# Issue:
https://app.asana.com/0/1181333741691281/1200438756262278

# Functionality changed
- Tracking page view based on value provided in pluginOption `trackPageView`
- Default value is set to `true`
